### PR TITLE
Example on how to use the schema

### DIFF
--- a/examples/quick_start_battery_monitor/battery_drainer.scxml
+++ b/examples/quick_start_battery_monitor/battery_drainer.scxml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scxml
+<ascxml
     initial="use_battery"
     version="1.0"
     name="BatteryDrainer"
     model_src=""
-    xmlns="http://www.w3.org/2005/07/scxml">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://github.com/convince-project/data-model/raw/refs/heads/fix_root_tag/data-format-specifications/skill-components-(A)SCXML/ascxml_component.xsd">
 
     <datamodel>
         <data id="battery_percent" expr="100" type="int16" />
@@ -27,4 +28,4 @@
             <assign location="battery_percent" expr="100" />
         </ros_topic_callback>
     </state>
-</scxml>
+</ascxml>

--- a/examples/quick_start_battery_monitor/battery_manager.scxml
+++ b/examples/quick_start_battery_monitor/battery_manager.scxml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scxml
+<ascxml
     initial="check_battery"
     version="1.0"
     name="BatteryManager"
     model_src=""
-    xmlns="http://www.w3.org/2005/07/scxml">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://github.com/convince-project/data-model/raw/refs/heads/fix_root_tag/data-format-specifications/skill-components-(A)SCXML/ascxml_component.xsd">
 
     <datamodel>
         <data id="battery_alarm" expr="false" type="bool" />
@@ -23,4 +24,4 @@
             </ros_topic_publish>
         </onentry>
     </state>
-</scxml>
+</ascxml>

--- a/examples/quick_start_battery_monitor/bt_topic_action.scxml
+++ b/examples/quick_start_battery_monitor/bt_topic_action.scxml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scxml
+<ascxml
     initial="initial"
     version="1.0"
     name="TopicAction"
     model_src=""
-    xmlns="http://www.w3.org/2005/07/scxml">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://github.com/convince-project/data-model/raw/refs/heads/fix_root_tag/data-format-specifications/bt-plugin-ASCXML/bt_plugin.xsd">
 
     <ros_topic_publisher topic="charge" type="std_msgs/Empty" />
 
@@ -21,4 +22,4 @@
         </bt_halt>
     </state>
 
-</scxml>
+</ascxml>

--- a/examples/quick_start_battery_monitor/bt_topic_condition.scxml
+++ b/examples/quick_start_battery_monitor/bt_topic_condition.scxml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scxml
+<ascxml
     initial="initial"
     version="1.0"
     name="TopicCondition"
     model_src=""
-    xmlns="http://www.w3.org/2005/07/scxml">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://github.com/convince-project/data-model/raw/refs/heads/fix_root_tag/data-format-specifications/bt-plugin-ASCXML/bt_plugin.xsd">
 
     <datamodel>
         <data id="last_msg" expr="false" type="bool" />
@@ -13,7 +14,8 @@
     <ros_topic_subscriber topic="alarm" type="std_msgs/Bool" />
 
     <!-- Assumption: We get an event when the node is ticked by the BT, named "bt_tick". -->
-    <!-- Assumption: We have to send an event to the BT, that is either "bt_success" or "bt_failure". -->
+    <!-- Assumption: We have to send an event to the BT, that is either "bt_success" or
+    "bt_failure". -->
 
     <state id="initial">
         <ros_topic_callback name="alarm" target="initial">
@@ -31,4 +33,4 @@
         </bt_halt>
     </state>
 
-</scxml>
+</ascxml>

--- a/examples/quick_start_battery_monitor/main.xml
+++ b/examples/quick_start_battery_monitor/main.xml
@@ -1,6 +1,6 @@
 <roaml
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://github.com/convince-project/data-model/raw/refs/heads/fix_root_tag/data-format-specifications/RoAML/main.xsd">
+    xsi:noNamespaceSchemaLocation="https://github.com/convince-project/data-model/raw/refs/heads/fix_root_tag/data-format-specifications/RoAML-XML/main.xsd">
     <mc_parameters>
         <max_time value="100" unit="s" />
         <bt_tick_rate value="1.0" />


### PR DESCRIPTION
This serves as a quick example on how to reference the schema without a namespace.
But ideally we should include one.