### PR TITLE
Feature strings with no quote in BT XML policy

### DIFF
--- a/src/as2fm/as2fm_common/array_type.py
+++ b/src/as2fm/as2fm_common/array_type.py
@@ -14,9 +14,9 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import List, MutableSequence, Optional, Tuple, Type, Union, get_args
+from typing import List, MutableSequence, Optional, Tuple, Type, Union
 
-from as2fm.as2fm_common.common import ValidPlainScxmlTypes
+from as2fm.as2fm_common.types import ValidPlainScxmlTypes
 
 ARRAY_BASE_TYPES = (int, float, None)
 
@@ -204,32 +204,3 @@ def get_padded_array(
 def is_array_type(field_type: Union[Type[ValidPlainScxmlTypes], ArrayInfo]) -> bool:
     """Check if the field type is an array type."""
     return field_type is MutableSequence or isinstance(field_type, ArrayInfo)
-
-
-def get_default_expression_for_type(field_type: Type[ValidPlainScxmlTypes]) -> ValidPlainScxmlTypes:
-    """Generate a default expression for a field type."""
-    assert field_type in get_args(
-        ValidPlainScxmlTypes
-    ), f"Error: Unsupported SCXML data type {field_type}."
-    if field_type is MutableSequence:
-        return []
-    if field_type is str:
-        return ""
-    else:
-        return field_type()
-
-
-def value_to_string_expr(value: ValidPlainScxmlTypes) -> str:
-    """Takes a python object and returns it as a (SCXML compatible) string."""
-    if isinstance(value, MutableSequence):
-        assert is_valid_array(value), f"Found invalid input array {value}."
-        # Expect value to be a list, so casting to string is enough.
-        return str(value)
-    elif isinstance(value, bool):
-        return str(value).lower()
-    elif isinstance(value, (int, float)):
-        return str(value)
-    elif isinstance(value, str):
-        return f"'{value}'"
-    else:
-        raise ValueError(f"Unsupported value type {type(value)}.")

--- a/src/as2fm/as2fm_common/common.py
+++ b/src/as2fm/as2fm_common/common.py
@@ -18,28 +18,13 @@ Common functionalities used throughout the toolchain.
 """
 
 import re
-from typing import MutableSequence, Type, Union
+from typing import MutableSequence, Type, get_args
 
 from lxml.etree import _Comment as XmlComment
 from lxml.etree import _Element as XmlElement
 
-# Set of basic types that are supported by the Jani language.
-# Basic types (from Jani docs):
-# Types
-# We cover only the most basic types at the moment.
-# In the remainder of the specification, all requirements like "y must be of type x" are to be
-# interpreted as "type x must be assignable from y's type".
-# var BasicType = schema([
-# "bool", // assignable from bool
-# "int", // numeric; assignable from int and bounded int
-# "real" // numeric; assignable from all numeric types
-# ]);
-# src https://docs.google.com/document/d/\
-#     1BDQIzPBtscxJFFlDUEPIo8ivKHgXT8_X6hz5quq7jK0/edit
-# Additionally, we support the array types from the array extension.
-ValidJaniTypes = Union[bool, int, float, MutableSequence]
-
-ValidPlainScxmlTypes = Union[bool, int, float, MutableSequence, str]
+from as2fm.as2fm_common.array_type import is_valid_array
+from as2fm.as2fm_common.types import ValidJaniTypes, ValidPlainScxmlTypes
 
 # Small number used for float comparison.
 EPSILON = 1e-3
@@ -100,3 +85,32 @@ def is_valid_variable_name(var_name: str) -> bool:
     Alternatively, a variable name can be a single character.
     """
     return re.match(r"^[a-zA-Z_][a-zA-Z0-9._-]*[a-zA-Z0-9]$|^[a-zA-Z]$", var_name) is not None
+
+
+def get_default_expression_for_type(field_type: Type[ValidPlainScxmlTypes]) -> ValidPlainScxmlTypes:
+    """Generate a default expression for a field type."""
+    assert field_type in get_args(
+        ValidPlainScxmlTypes
+    ), f"Error: Unsupported SCXML data type {field_type}."
+    if field_type is MutableSequence:
+        return []
+    if field_type is str:
+        return ""
+    else:
+        return field_type()
+
+
+def value_to_string_expr(value: ValidPlainScxmlTypes) -> str:
+    """Takes a python object and returns it as a (SCXML compatible) string."""
+    if isinstance(value, MutableSequence):
+        assert is_valid_array(value), f"Found invalid input array {value}."
+        # Expect value to be a list, so casting to string is enough.
+        return str(value)
+    elif isinstance(value, bool):
+        return str(value).lower()
+    elif isinstance(value, (int, float)):
+        return str(value)
+    elif isinstance(value, str):
+        return f"'{value}'"
+    else:
+        raise ValueError(f"Unsupported value type {type(value)}.")

--- a/src/as2fm/as2fm_common/common.py
+++ b/src/as2fm/as2fm_common/common.py
@@ -111,6 +111,9 @@ def value_to_string_expr(value: ValidPlainScxmlTypes) -> str:
     elif isinstance(value, (int, float)):
         return str(value)
     elif isinstance(value, str):
+        # Make sure to correctly escape quotes
+        value = value.replace("'", r"\'")
+        # Add quotes around the value, to make it a valid JS string
         return f"'{value}'"
     else:
         raise ValueError(f"Unsupported value type {type(value)}.")

--- a/src/as2fm/as2fm_common/types.py
+++ b/src/as2fm/as2fm_common/types.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026 - for information on the respective copyright owner
+# see the NOTICE file
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import MutableSequence, Union
+
+# Set of basic types that are supported by the Jani language.
+# Basic types (from Jani docs):
+# Types
+# We cover only the most basic types at the moment.
+# In the remainder of the specification, all requirements like "y must be of type x" are to be
+# interpreted as "type x must be assignable from y's type".
+# var BasicType = schema([
+# "bool", // assignable from bool
+# "int", // numeric; assignable from int and bounded int
+# "real" // numeric; assignable from all numeric types
+# ]);
+# src https://docs.google.com/document/d/\
+#     1BDQIzPBtscxJFFlDUEPIo8ivKHgXT8_X6hz5quq7jK0/edit
+# Additionally, we support the array types from the array extension.
+ValidJaniTypes = Union[bool, int, float, MutableSequence]
+
+ValidPlainScxmlTypes = Union[bool, int, float, MutableSequence, str]

--- a/src/as2fm/jani_generator/jani_entries/jani_utils.py
+++ b/src/as2fm/jani_generator/jani_entries/jani_utils.py
@@ -17,8 +17,9 @@
 
 from typing import List, MutableSequence, Optional, Tuple, Type, Union
 
-from as2fm.as2fm_common.array_type import ArrayInfo, get_default_expression_for_type, is_array_type
-from as2fm.as2fm_common.common import ValidJaniTypes
+from as2fm.as2fm_common.array_type import ArrayInfo, is_array_type
+from as2fm.as2fm_common.common import get_default_expression_for_type
+from as2fm.as2fm_common.types import ValidJaniTypes
 from as2fm.jani_generator.jani_entries import JaniExpression, JaniExpressionType, JaniVariable
 from as2fm.jani_generator.jani_entries.jani_expression_generator import array_create_operator
 

--- a/src/as2fm/jani_generator/jani_entries/jani_variable.py
+++ b/src/as2fm/jani_generator/jani_entries/jani_variable.py
@@ -20,7 +20,7 @@ Variables in Jani
 from typing import MutableSequence, Optional, Tuple, Type, Union, get_args
 
 from as2fm.as2fm_common.array_type import ArrayInfo
-from as2fm.as2fm_common.common import ValidJaniTypes
+from as2fm.as2fm_common.types import ValidJaniTypes
 from as2fm.jani_generator.jani_entries import JaniExpression, JaniValue
 from as2fm.jani_generator.jani_entries.jani_expression import SupportedExp
 

--- a/src/as2fm/jani_generator/ros_helpers/ros_communication_handler.py
+++ b/src/as2fm/jani_generator/ros_helpers/ros_communication_handler.py
@@ -19,7 +19,7 @@ Generic class for generators of SCXML state machine for specific ROS communicati
 
 from typing import Dict, Iterator, List, Optional, Type
 
-from as2fm.as2fm_common.array_type import get_default_expression_for_type, value_to_string_expr
+from as2fm.as2fm_common.common import get_default_expression_for_type, value_to_string_expr
 from as2fm.jani_generator.jani_entries import JaniModel
 from as2fm.scxml_converter.ascxml_extensions.ros_entries import RosDeclaration
 from as2fm.scxml_converter.data_types.type_utils import get_data_type_from_string

--- a/src/as2fm/scxml_converter/ascxml_extensions/bt_entries/scxml_bt_port_declaration.py
+++ b/src/as2fm/scxml_converter/ascxml_extensions/bt_entries/scxml_bt_port_declaration.py
@@ -23,9 +23,13 @@ from lxml import etree as ET
 from lxml.etree import _Element as XmlElement
 from typing_extensions import Self
 
+from as2fm.as2fm_common.common import value_to_string_expr
 from as2fm.as2fm_common.logging import check_assertion
 from as2fm.scxml_converter.ascxml_extensions.bt_entries.bt_utils import is_blackboard_reference
 from as2fm.scxml_converter.data_types.struct_definition import StructDefinition
+from as2fm.scxml_converter.data_types.type_utils import (
+    convert_string_to_type,
+)
 from as2fm.scxml_converter.scxml_entries import AscxmlDeclaration
 from as2fm.scxml_converter.scxml_entries.utils import is_non_empty_string
 from as2fm.scxml_converter.scxml_entries.xml_utils import assert_xml_tag_ok, get_xml_attribute
@@ -62,7 +66,13 @@ class BtGenericPortDeclaration(AscxmlDeclaration):
             self.get_xml_origin(),
             f"Multiple assignments to BT port {self._key}",
         )
-        self._value = val
+        if is_blackboard_reference(val):
+            # If this is a blackboard reference, keep it as is
+            self._value = val
+        else:
+            # Try casting the input string to the required type
+            casted_value = convert_string_to_type(val, self._type, self.get_xml_origin())
+            self._value = value_to_string_expr(casted_value)
 
     def get_key_value(self) -> Optional[str]:
         return self._value

--- a/src/as2fm/scxml_converter/ascxml_extensions/ros_entries/scxml_ros_base.py
+++ b/src/as2fm/scxml_converter/ascxml_extensions/ros_entries/scxml_ros_base.py
@@ -23,7 +23,7 @@ from lxml.etree import _Element as XmlElement
 from typing_extensions import Self
 
 from as2fm.as2fm_common.common import is_comment
-from as2fm.as2fm_common.logging import get_error_msg, log_error, log_warning
+from as2fm.as2fm_common.logging import check_assertion, get_error_msg, log_error, log_warning
 from as2fm.scxml_converter.ascxml_extensions.ros_entries import RosField
 from as2fm.scxml_converter.data_types.struct_definition import StructDefinition
 from as2fm.scxml_converter.scxml_entries import (
@@ -175,6 +175,18 @@ class RosDeclaration(AscxmlDeclaration):
                 self.get_xml_origin(), "ROS declaration expect constant configurable values."
             )
             self._interface_name = self._interface_name.get_configured_value()
+            # Expect this to be a JS script: have quotes at start and end
+            has_quotes_wrap = self._interface_name.startswith(
+                "'"
+            ) and self._interface_name.endswith("'")
+            check_assertion(
+                has_quotes_wrap,
+                self.get_xml_origin(),
+                f"Unexpected interface name from config {self._interface_name}: "
+                "should be wrapped by quotes.",
+            )
+            # Remove first and last character (the quotes)
+            self._interface_name = self._interface_name[1:-1]
 
     def as_plain_scxml(self, struct_declarations, ascxml_declarations, **kwargs) -> List[ScxmlBase]:
         # This is discarded in the to_plain_scxml_and_declarations method from ScxmlRoot

--- a/src/as2fm/scxml_converter/bt_converter.py
+++ b/src/as2fm/scxml_converter/bt_converter.py
@@ -25,7 +25,7 @@ from typing import Dict, List, Optional, Tuple
 from lxml import etree as ET
 from lxml.etree import _Element as XmlElement
 
-from as2fm.as2fm_common.array_type import get_default_expression_for_type, value_to_string_expr
+from as2fm.as2fm_common.common import get_default_expression_for_type, value_to_string_expr
 from as2fm.as2fm_common.logging import (
     INTERNAL_FILEPATH_ATTR,
     get_error_msg,

--- a/src/as2fm/scxml_converter/data_types/type_utils.py
+++ b/src/as2fm/scxml_converter/data_types/type_utils.py
@@ -92,9 +92,11 @@ def convert_string_to_type(value: str, data_type: str, elem: XmlElement) -> Any:
     if expected_type is str:
         return value
     interpreted_type = parse_ecmascript_expr_to_type(value, {}, elem)
-    assert (
-        interpreted_type is expected_type
-    ), f"Mismatched type: {value} evaluates to {interpreted_type}, but {expected_type} is expected."
+    check_assertion(
+        interpreted_type is expected_type,
+        elem,
+        f"Mismatched type: {value} evaluates to {interpreted_type} != {expected_type} (expected).",
+    )
     return interpreted_type(value)
 
 

--- a/src/as2fm/scxml_converter/data_types/type_utils.py
+++ b/src/as2fm/scxml_converter/data_types/type_utils.py
@@ -20,6 +20,7 @@ from lxml.etree import _Element as XmlElement
 
 from as2fm.as2fm_common.array_type import ArrayInfo
 from as2fm.as2fm_common.ecmascript_interpretation import parse_ecmascript_expr_to_type
+from as2fm.as2fm_common.logging import check_assertion
 
 # TODO: add lower and upper bounds depending on the n. of bits used.
 # TODO: add support to uint
@@ -87,9 +88,9 @@ def convert_string_to_type(value: str, data_type: str, elem: XmlElement) -> Any:
     Convert a value to the provided data type.
     """
     expected_type = get_data_type_from_string(data_type)
+    check_assertion(isinstance(value, str), elem, f"Arg. 'value' has type {type(value)} != str")
     if expected_type is str:
-        value = value.replace("'", r"\'")
-        value = f"'{value}'"
+        return value
     interpreted_type = parse_ecmascript_expr_to_type(value, {}, elem)
     assert (
         interpreted_type is expected_type

--- a/src/as2fm/scxml_converter/data_types/type_utils.py
+++ b/src/as2fm/scxml_converter/data_types/type_utils.py
@@ -87,9 +87,12 @@ def convert_string_to_type(value: str, data_type: str, elem: XmlElement) -> Any:
     Convert a value to the provided data type.
     """
     expected_type = get_data_type_from_string(data_type)
+    if expected_type is str:
+        value = value.replace("'", r"\'")
+        value = f"'{value}'"
     interpreted_type = parse_ecmascript_expr_to_type(value, {}, elem)
-    assert isinstance(
-        interpreted_type, expected_type
+    assert (
+        interpreted_type is expected_type
     ), f"Mismatched type: {value} evaluates to {interpreted_type}, but {expected_type} is expected."
     return interpreted_type(value)
 

--- a/test/jani_generator/_test_data/blackboard_test/bt.xml
+++ b/test/jani_generator/_test_data/blackboard_test/bt.xml
@@ -2,8 +2,10 @@
     <BehaviorTree ID="blackboard_test">
         <ReactiveSequence name="bb_test">
             <!-- Store goal and robot pose in 4 blackboard variables -->
-            <Action ID="WriteBB" bb_var="{counter}" />
-            <Action ID="ReadBB" bb_var="{counter}" target="10" />
+            <WriteBB bb_var="{counter}" />
+            <ReadBB bb_var="{counter}" target="10" />
+            <!-- Testing that strings do not require quotes -->
+            <ReadBB_str bb_var="test" />
         </ReactiveSequence>
     </BehaviorTree>
 </root>

--- a/test/jani_generator/_test_data/blackboard_test/bt_read_bb_str.ascxml
+++ b/test/jani_generator/_test_data/blackboard_test/bt_read_bb_str.ascxml
@@ -11,7 +11,6 @@
 
     <datamodel>
         <data id="bb_var" expr="''" type="string" />
-        <data id="target" expr="'test'" type="string" />
     </datamodel>
 
     <state id="wait_for_tick">
@@ -29,7 +28,7 @@
                 </expr>
             </assign>
             <!-- Leaf node tick -->
-            <if cond="bb_var == target">
+            <if cond="bb_var == 'test'">
                 <bt_return_status status="SUCCESS" />
             <else />
                 <bt_return_status status="FAILURE" />

--- a/test/jani_generator/_test_data/blackboard_test/bt_read_bb_str.ascxml
+++ b/test/jani_generator/_test_data/blackboard_test/bt_read_bb_str.ascxml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ascxml
+    initial="wait_for_tick"
+    version="1.0"
+    name="ReadBB_str"
+    model_src=""
+    xmlns="http://www.w3.org/2005/07/scxml">
+
+    <!-- A node that ensures the input port contains the string "test" -->
+    <bt_declare_port_in key="bb_var" type="string" />
+
+    <datamodel>
+        <data id="bb_var" expr="''" type="string" />
+        <data id="target" expr="'test'" type="string" />
+    </datamodel>
+
+    <state id="wait_for_tick">
+        <bt_tick target="running" />
+        <bt_halt target="wait_for_tick">
+            <bt_return_halted />
+        </bt_halt>
+    </state>
+
+    <state id="running">
+        <transition target="wait_for_tick">
+            <assign location="bb_var">
+                <expr>
+                    <bt_get_input key="bb_var" />
+                </expr>
+            </assign>
+            <!-- Leaf node tick -->
+            <if cond="bb_var == target">
+                <bt_return_status status="SUCCESS" />
+            <else />
+                <bt_return_status status="FAILURE" />
+            </if>
+        </transition>
+    </state>
+
+</ascxml>

--- a/test/jani_generator/_test_data/blackboard_test/main.xml
+++ b/test/jani_generator/_test_data/blackboard_test/main.xml
@@ -8,6 +8,7 @@
     <behavior_tree>
         <input type="bt.cpp-xml" src="./bt.xml" />
         <input type="bt-plugin-ascxml" src="./bt_read_bb.ascxml" />
+        <input type="bt-plugin-ascxml" src="./bt_read_bb_str.ascxml" />
         <input type="bt-plugin-ascxml" src="./bt_write_bb.ascxml" />
     </behavior_tree>
 

--- a/test/jani_generator/_test_data/uc1_docking/bt_simple_wait.ascxml
+++ b/test/jani_generator/_test_data/uc1_docking/bt_simple_wait.ascxml
@@ -9,16 +9,15 @@
     <datamodel>
         <data id="waiting" expr="false" type="bool" />
         <data id="n_waited" expr="0" type="int16" />
-        <data id="wait_duration_s" expr="0" type="int16" />
+        <data id="wait_duration_s" expr="0" type="float32" />
     </datamodel>
 
-    <bt_declare_port_in key="wait_duration" type="int16" />
+    <bt_declare_port_in key="wait_duration" type="float32" />
     <ros_time_rate rate_hz="10" name="wait_timer" />
 
     <state id="initial">
         <bt_tick target="initial">
-            <!-- In a Reactive sequence, if another node fails we should reset this... -->
-            <if cond="waiting == false">  <!-- TODO: support !waiting later on-->
+            <if cond="!waiting">
                 <assign location="waiting" expr="true" />
                 <assign location="n_waited" expr="0" />
                 <assign location="wait_duration_s">
@@ -28,7 +27,7 @@
                 </assign>
                 <bt_return_status status="RUNNING" />
             <else/>
-                <if cond="n_waited >= wait_duration_s * 10">
+                <if cond="n_waited * 0.1 >= wait_duration_s">
                     <bt_return_status status="SUCCESS" />
                 <else/>
                     <bt_return_status status="RUNNING" />

--- a/test/jani_generator/test_systemtest_main_xml_to_jani.py
+++ b/test/jani_generator/test_systemtest_main_xml_to_jani.py
@@ -482,6 +482,8 @@ def get_cases():
             "folder": "uc1_docking",
             "property_name": "charging_starts",
             "trace_length_limit": 1_000_000,
+            "n_threads": 8,
+            "disable_cache": True,
         },
         # UC1 docking BT (with a bug).
         _default_case()
@@ -493,6 +495,7 @@ def get_cases():
             "expected_result_probability": 0.0,
             "trace_length_limit": 1_000_000,
             "n_threads": 8,
+            "disable_cache": True,
         },
         # UC1 Complete Mission
         _default_case()


### PR DESCRIPTION
With this change, we do not need to wrap strings in the BT.xml ports with single quotes.
If strings contain quotes, they will be considered part of the string itself (via escaping).
This means `BT Port = "'aaa'"` -> `ASCXML data = "'\'aaa\''"`